### PR TITLE
Abstract the encoding to a separate interface 

### DIFF
--- a/pkg/encoding.go
+++ b/pkg/encoding.go
@@ -1,0 +1,14 @@
+package cache
+
+type Encoder interface {
+	Encode(*Item) ([]byte, error)
+}
+
+type Decoder interface {
+	Decode([]byte) (*Item, error)
+}
+
+type Encoding interface {
+	Encoder
+	Decoder
+}

--- a/pkg/gob_encoding.go
+++ b/pkg/gob_encoding.go
@@ -1,0 +1,36 @@
+package cache
+
+import (
+	"bytes"
+	"encoding/gob"
+	"github.com/pkg/errors"
+)
+
+var GobEncoding Encoding = NewGobEncoding()
+
+func NewGobEncoding() *gobEncoding {
+	return &gobEncoding{}
+}
+
+type gobEncoding struct {}
+
+func (e *gobEncoding) Encode(item *Item) ([]byte, error) {
+	encoded := &bytes.Buffer{}
+	enc := gob.NewEncoder(encoded)
+	if err := enc.Encode(*item); err != nil {
+		return nil, errors.Wrap(err, "unable to encode item")
+	}
+
+	return encoded.Bytes(), nil
+}
+
+func (e *gobEncoding) Decode(data []byte) (*Item, error) {
+	dec := gob.NewDecoder(bytes.NewReader(data))
+	var item Item
+	if err := dec.Decode(&item); err != nil {
+		return nil, errors.Wrap(err, "unable to decode item")
+	}
+
+	return &item, nil
+
+}

--- a/pkg/gob_encoding_test.go
+++ b/pkg/gob_encoding_test.go
@@ -1,0 +1,40 @@
+package cache
+
+import (
+	"encoding/gob"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_gobEncoding(t *testing.T) {
+	type test struct {
+		Foo string
+	}
+	gob.Register(test{})
+
+	tests := map[string]Item{
+		"empty":      {},
+		"expiration": {Expiration: time.Unix(10000, 0)},
+		"struct":     {Data: test{Foo: "bar"}},
+		"integer":    {Data: 123},
+		"float":      {Data: 1.2},
+		"string":     {Data: "123"},
+		"nil":        {Data: nil},
+	}
+
+	for name, item := range tests {
+		t.Run(name, func(t *testing.T) {
+			enc, err := GobEncoding.Encode(&item)
+			assert.NoError(t, err)
+			assert.NotNil(t, enc)
+
+			dec, err := GobEncoding.Decode(enc)
+			assert.NoError(t, err)
+			assert.NotNil(t, dec)
+
+			assert.EqualValues(t, item, *dec)
+		})
+	}
+}

--- a/pkg/memcached_test.go
+++ b/pkg/memcached_test.go
@@ -1,10 +1,8 @@
 package cache
 
 import (
-	"encoding/gob"
 	"net"
 	"testing"
-	"time"
 
 	"github.com/bradfitz/gomemcache/memcache"
 	"github.com/stretchr/testify/assert"
@@ -13,37 +11,6 @@ import (
 func ExampleNewMemcacheClient() {
 	memcacheClient := memcache.New("localhost:11211")
 	NewMemcacheClient(memcacheClient)
-}
-
-func Test_encodeMemcacheItem(t *testing.T) {
-	type test struct {
-		Foo string
-	}
-	gob.Register(test{})
-
-	tests := map[string]Item{
-		"empty":      {},
-		"expiration": {Expiration: time.Unix(10000, 0)},
-		"struct":     {Data: test{Foo: "bar"}},
-		"integer":    {Data: 123},
-		"float":      {Data: 1.2},
-		"string":     {Data: "123"},
-		"nil":        {Data: nil},
-	}
-
-	for name, item := range tests {
-		t.Run(name, func(t *testing.T) {
-			enc, err := encodeMemcacheItem(name, &item)
-			assert.NoError(t, err)
-			assert.NotNil(t, enc)
-
-			dec, err := decodeMemcacheItem(enc)
-			assert.NoError(t, err)
-			assert.NotNil(t, dec)
-
-			assert.EqualValues(t, item, *dec)
-		})
-	}
 }
 
 func Test_coalesceTimeoutError(t *testing.T) {


### PR DESCRIPTION
Does not expose the encoding as an option for Memcache in order to maintain compatibility