### PR TITLE
Add a literal encoding

### DIFF
--- a/pkg/client.go
+++ b/pkg/client.go
@@ -31,6 +31,15 @@ func TtlForExpiration(t time.Time) time.Duration {
 	return time.Until(t)
 }
 
+func setPointerValue(ptr interface{}, value interface{}) error {
+	if !isPointer(ptr) {
+		return ErrNotAPointer
+	}
+
+	reflect.ValueOf(ptr).Elem().Set(reflect.ValueOf(value))
+	return nil
+}
+
 func isPointer(data interface{}) bool {
 	switch reflect.ValueOf(data).Kind() {
 	case reflect.Ptr, reflect.Interface:

--- a/pkg/encoding_test.go
+++ b/pkg/encoding_test.go
@@ -7,6 +7,90 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// Results:
+//
+// encoding   format  operation   ns/op
+// json       int     encode      187
+// json       float64 encode      270
+// json       string  encode      192
+// json       int     decode      274
+// json       float64 decode      356
+// json       string  decode      322
+// literal    int     encode      75.3
+// literal    float64 encode      187
+// literal    string  encode      45.7
+// literal    int     decode      105
+// literal    float64 decode      124
+// literal    string  decode      92.8
+// gob        int     encode      1004
+// gob        float64 encode      1034
+// gob        string  encode      1000
+// gob        int     decode      480
+// gob        float64 decode      486
+// gob        string  decode      491
+//
+// Average of operations and types:
+// encoding	 ns/op
+// literal	 105
+// json		 267
+// gob       749
+//
+func BenchmarkEncoding(b *testing.B) {
+	benchmarks := map[string]Encoding{
+		"gob":     GobEncoding,
+		"json":    JsonEncoding,
+		"literal": NewLiteralEncoding(nil),
+	}
+	for name, encoding := range benchmarks {
+		b.Run(name, func(b *testing.B) {
+			b.Run("int", func(b *testing.B) {
+				b.Run("encode", func(b *testing.B) {
+					for i := 0; i < b.N; i++ {
+						_, _ = encoding.Encode(123)
+					}
+				})
+
+				b.Run("decode", func(b *testing.B) {
+					for i := 0; i < b.N; i++ {
+						var val int
+						_ = encoding.Decode([]byte("123"), &val)
+					}
+				})
+			})
+
+			b.Run("float64", func(b *testing.B) {
+				b.Run("encode", func(b *testing.B) {
+					for i := 0; i < b.N; i++ {
+						_, _ = encoding.Encode(12.3)
+					}
+				})
+
+				b.Run("decode", func(b *testing.B) {
+					for i := 0; i < b.N; i++ {
+						var val float64
+						_ = encoding.Decode([]byte("12.3"), &val)
+					}
+				})
+			})
+
+			b.Run("string", func(b *testing.B) {
+				b.Run("encode", func(b *testing.B) {
+					for i := 0; i < b.N; i++ {
+						_, _ = encoding.Encode("123")
+					}
+				})
+
+				b.Run("decode", func(b *testing.B) {
+					for i := 0; i < b.N; i++ {
+						var val string
+						_ = encoding.Decode([]byte("123"), &val)
+					}
+				})
+			})
+		})
+	}
+}
+
 type testStruct struct {
 	Foo string
 }
@@ -110,7 +194,7 @@ func testEncoding(t *testing.T, encoding Encoding) {
 	})
 
 	t.Run("wrong type", func(t *testing.T) {
-		enc, err := encoding.Encode("123")
+		enc, err := encoding.Encode("12.3")
 		require.NoError(t, err)
 		require.NotNil(t, enc)
 

--- a/pkg/literal_encoding.go
+++ b/pkg/literal_encoding.go
@@ -1,0 +1,117 @@
+package cache
+
+import (
+	"reflect"
+	"strconv"
+)
+
+var _ Encoding = &literalEncoding{}
+
+// NewLiteralEncoding is an encoding that will try its best to store the data as is,
+// but fallback on another encoder if not possible.
+func NewLiteralEncoding(fallback Encoding) *literalEncoding {
+	return &literalEncoding{fallback: fallback}
+}
+
+var translators = map[reflect.Kind]*translator{}
+
+type translator struct {
+	encode func(val reflect.Value) []byte
+	decode func(data []byte, target reflect.Value) error
+}
+
+func init() {
+	uintTranslator := &translator{
+		func(val reflect.Value) []byte { return []byte(strconv.FormatUint(val.Uint(), 10)) },
+		func(data []byte, target reflect.Value) error {
+			if val, err := strconv.ParseUint(string(data), 10, 64); err == nil {
+				target.SetUint(val)
+				return nil
+			} else {
+				return err
+			}
+		},
+	}
+	translators[reflect.Uint] = uintTranslator
+	translators[reflect.Uint8] = uintTranslator
+	translators[reflect.Uint16] = uintTranslator
+	translators[reflect.Uint32] = uintTranslator
+	translators[reflect.Uint64] = uintTranslator
+
+	intTranslator := &translator{
+		func(val reflect.Value) []byte { return []byte(strconv.FormatInt(val.Int(), 10)) },
+		func(data []byte, target reflect.Value) error {
+			if val, err := strconv.ParseInt(string(data), 10, 64); err == nil {
+				target.SetInt(val)
+				return nil
+			} else {
+				return err
+			}
+		},
+	}
+	translators[reflect.Int] = intTranslator
+	translators[reflect.Int8] = intTranslator
+	translators[reflect.Int16] = intTranslator
+	translators[reflect.Int32] = intTranslator
+	translators[reflect.Int64] = intTranslator
+
+	floatTranslator := &translator{
+		func(val reflect.Value) []byte { return []byte(strconv.FormatFloat(val.Float(), 'f', -1, 64)) },
+		func(data []byte, target reflect.Value) error {
+			if val, err := strconv.ParseFloat(string(data), 64); err == nil {
+				target.SetFloat(val)
+				return nil
+			} else {
+				return err
+			}
+		},
+	}
+	translators[reflect.Float32] = floatTranslator
+	translators[reflect.Float64] = floatTranslator
+
+	translators[reflect.String] = &translator{
+		func(val reflect.Value) []byte { return []byte(val.String()) },
+		func(data []byte, target reflect.Value) error {
+			target.SetString(string(data))
+			return nil
+		},
+	}
+
+	translators[reflect.Bool] = &translator{
+		func(val reflect.Value) []byte { return []byte(strconv.FormatBool(val.Bool())) },
+		func(data []byte, target reflect.Value) error {
+			if val, err := strconv.ParseBool(string(data)); err == nil {
+				target.SetBool(val)
+				return nil
+			} else {
+				return err
+			}
+		},
+	}
+}
+
+type literalEncoding struct {
+	fallback Encoding
+}
+
+func (e *literalEncoding) Encode(data interface{}) ([]byte, error) {
+	value := reflect.ValueOf(data)
+	if t, ok := translators[value.Kind()]; ok {
+		return t.encode(value), nil
+	}
+
+	return e.fallback.Encode(data)
+}
+
+func (e *literalEncoding) Decode(b []byte, data interface{}) error {
+	if !isPointer(data) {
+		return ErrNotAPointer
+	}
+
+	kind := reflect.ValueOf(data).Elem().Kind()
+	if t, ok := translators[kind]; ok {
+		return t.decode(b, reflect.ValueOf(data).Elem())
+	}
+
+	return e.fallback.Decode(b, data)
+}

--- a/pkg/literal_encoding_test.go
+++ b/pkg/literal_encoding_test.go
@@ -1,0 +1,14 @@
+package cache
+
+import (
+	"fmt"
+	"testing"
+)
+
+func Test_literalEncoding(t *testing.T) {
+	for _, e := range []Encoding{JsonEncoding, GobEncoding} {
+		t.Run(fmt.Sprintf("%T", e), func(t *testing.T) {
+			testEncoding(t, NewLiteralEncoding(e))
+		})
+	}
+}

--- a/pkg/memory.go
+++ b/pkg/memory.go
@@ -1,7 +1,6 @@
 package cache
 
 import (
-	"reflect"
 	"sync"
 	"time"
 )
@@ -25,12 +24,7 @@ func (c *memoryClient) Get(key string, data interface{}) error {
 	if item, ok := c.data.Load(key); ok {
 		mItem := item.(memoryData)
 		if mItem.expiration.IsZero() || mItem.expiration.After(time.Now()) {
-			if !isPointer(data) {
-				return ErrNotAPointer
-			}
-
-			reflect.ValueOf(data).Elem().Set(reflect.ValueOf(mItem.data))
-			return nil
+			return setPointerValue(data, mItem.data)
 		}
 	}
 	return ErrCacheMiss


### PR DESCRIPTION
An encoding that will try its best to store the data as is, but fallback on another encoder if not possible.

This is useful when the data needs to be raw, like if doing operations on the raw integers is necessary.