### PR TITLE
Require go 1.13+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 sudo: false
 language: go
 go:
-- 1.11
-- 1.12
 - 1.13
+- 1.14
+- 1.15
 - tip
 go_import_path: github.com/Shopify/go-cache
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Inspired from https://github.com/gookit/cache, but designed to be wrapped, simil
 
 # Requirements
 
-- [Go 1.10+](http://golang.org/dl/)
+- [Go 1.13+](http://golang.org/dl/)
 
 # Installation
 

--- a/dev.yml
+++ b/dev.yml
@@ -2,7 +2,7 @@ name: go-cache
 
 up:
   - go:
-      version: "1.13.5"
+      version: "1.15.2"
       modules: true
       tools:
         - github.com/alecthomas/gometalinter


### PR DESCRIPTION
- Drop tests for go 1.11 and 1.12
- Update README