### PR TITLE
Split integration tests

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -3,10 +3,10 @@ name: CI
 on:
   push:
     tags:
-      - v*
+    - v*
     branches:
-      - master
-      - main
+    - master
+    - main
   pull_request:
 
 jobs:
@@ -15,40 +15,40 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
+    - name: Checkout
+      uses: actions/checkout@v2
 
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
-        with:
-          version: v1.32
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v2
+      with:
+        version: v1.32
 
   mod-tidy:
     name: Go Mod Tidy
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
+    - name: Checkout
+      uses: actions/checkout@v2
 
-      - name: Setup go
-        uses: actions/setup-go@v1
-        with:
-          go-version: 1.15.x
+    - name: Setup go
+      uses: actions/setup-go@v1
+      with:
+        go-version: 1.15.x
 
-      - name: Cache
-        uses: actions/cache@v1
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+    - name: Cache
+      uses: actions/cache@v1
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
 
-      - name: Tidy
-        run: |
-          cp go.sum{,.old}
-          go mod tidy
-          diff go.sum{.old,}
+    - name: Tidy
+      run: |
+        cp go.sum{,.old}
+        go mod tidy
+        diff go.sum{.old,}
 
   test:
     name: Go ${{ matrix.go-version }} test
@@ -57,37 +57,100 @@ jobs:
     strategy:
       matrix:
         go-version:
-          - 1.13.x
-          - 1.14.x
-          - 1.15.x
+        - 1.13.x
+        - 1.14.x
+        - 1.15.x
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
+    - name: Checkout
+      uses: actions/checkout@v2
 
-      - name: Setup go
-        uses: actions/setup-go@v1
-        with:
-          go-version: ${{ matrix.go-version }}
+    - name: Setup go
+      uses: actions/setup-go@v1
+      with:
+        go-version: ${{ matrix.go-version }}
 
-      - name: Cache
-        uses: actions/cache@v1
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+    - name: Cache
+      uses: actions/cache@v1
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
 
-      - name: Memcached Service
-        uses: niden/actions-memcached@v7
+    - name: Test
+      run: go test -v -race ./...
 
-      - name: Redis Service
-        uses: supercharge/redis-github-action@1.1.0
-        with:
-          redis-version: 6
+  memcached-tests:
+    name: Memcached tests
+    runs-on: ubuntu-latest
 
-      - name: Test
-        run: go test -v -race ./...
-        env:
-          MEMCACHED_SERVERS: localhost:11211
-          REDIS_URL: redis://localhost:6379
+    strategy:
+      matrix:
+        go-version:
+        - 1.x
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Setup go
+      uses: actions/setup-go@v1
+      with:
+        go-version: ${{ matrix.go-version }}
+
+    - name: Cache
+      uses: actions/cache@v1
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+
+    - name: Memcached Service
+      uses: niden/actions-memcached@v7
+
+    - name: Test
+      run: go test -v -race ./...
+      env:
+        MEMCACHED_SERVERS: localhost:11211
+
+  redis-tests:
+    name: Redis v${{ matrix.redis-version }} tests
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        go-version:
+        - 1.x
+        redis-version:
+        - 4
+        - 5
+        - 6
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Setup go
+      uses: actions/setup-go@v1
+      with:
+        go-version: ${{ matrix.go-version }}
+
+    - name: Cache
+      uses: actions/cache@v1
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+
+    - name: Redis Service
+      uses: supercharge/redis-github-action@1.1.0
+      with:
+        redis-version: ${{ matrix.redis-version }}
+
+    - name: Test
+      run: go test -v -race ./...
+      env:
+        REDIS_URL: redis://localhost:6379


### PR DESCRIPTION
- Run unit tests on all go versions
- Run memcached tests on latest go version
- Run redis tests on latest go version and redis 4, 5, 6

This should provide a good coverage, while not exploding the test matrix