### PR TITLE
BREAKING: Add context as a parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2
+
+- Add context as first argument
+
 ## v1
 
 - First stable release

--- a/client.go
+++ b/client.go
@@ -1,6 +1,7 @@
 package cache
 
 import (
+	"context"
 	"reflect"
 	"time"
 )
@@ -10,29 +11,29 @@ type Client interface {
 	// Get gets the item for the given key.
 	// Returns nil for a cache miss.
 	// The key must be at most 250 bytes in length.
-	Get(key string, data interface{}) error
+	Get(ctx context.Context, key string, data interface{}) error
 
 	// Set writes the given item, unconditionally.
-	Set(key string, data interface{}, expiration time.Time) error
+	Set(ctx context.Context, key string, data interface{}, expiration time.Time) error
 
 	// Add writes the given item, if no value already exists for its
 	// key. ErrNotStored is returned if that condition is not met.
-	Add(key string, data interface{}, expiration time.Time) error
+	Add(ctx context.Context, key string, data interface{}, expiration time.Time) error
 
 	// Delete deletes the item with the provided key, if it exists.
-	Delete(key string) error
+	Delete(ctx context.Context, key string) error
 
 	// Increment adds delta to the currently stored number
 	// If the key does not exist, it will be initialized to 0 with no expiration.
 	// If the value overflows, it will loop around from 0
 	// For many client implementations, you need to be using a LiteralEncoding for this feature to work
-	Increment(key string, delta uint64) (uint64, error)
+	Increment(ctx context.Context, key string, delta uint64) (uint64, error)
 
 	// Decrement subtracts delta to the currently stored number
 	// If the key does not exist, it will be initialized to 0 with no expiration, which will make it overflow.
 	// If the value overflows, it will loop around from MaxUint64
 	// For many client implementations, you need to be using a LiteralEncoding for this feature to work
-	Decrement(key string, delta uint64) (uint64, error)
+	Decrement(ctx context.Context, key string, delta uint64) (uint64, error)
 }
 
 var NeverExpire time.Time

--- a/redis.go
+++ b/redis.go
@@ -17,8 +17,8 @@ type redisClient struct {
 	encoding encoding.ValueEncoding
 }
 
-func (c *redisClient) Get(key string, data interface{}) error {
-	cmd := c.client.Get(context.Background(), key)
+func (c *redisClient) Get(ctx context.Context, key string, data interface{}) error {
+	cmd := c.client.Get(ctx, key)
 	b, err := cmd.Bytes()
 	if err != nil {
 		if err == redis.Nil {
@@ -30,42 +30,42 @@ func (c *redisClient) Get(key string, data interface{}) error {
 	return c.encoding.Decode(b, data)
 }
 
-func (c *redisClient) Set(key string, data interface{}, expiration time.Time) error {
+func (c *redisClient) Set(ctx context.Context, key string, data interface{}, expiration time.Time) error {
 	data, err := c.encoding.Encode(data)
 	if err != nil {
 		return err
 	}
 
-	cmd := c.client.Set(context.Background(), key, data, ttlForExpiration(expiration))
+	cmd := c.client.Set(ctx, key, data, ttlForExpiration(expiration))
 	return cmd.Err()
 }
 
-func (c *redisClient) Add(key string, data interface{}, expiration time.Time) error {
+func (c *redisClient) Add(ctx context.Context, key string, data interface{}, expiration time.Time) error {
 	b, err := c.encoding.Encode(data)
 	if err != nil {
 		return err
 	}
 
-	cmd := c.client.SetNX(context.Background(), key, b, ttlForExpiration(expiration))
+	cmd := c.client.SetNX(ctx, key, b, ttlForExpiration(expiration))
 	if !cmd.Val() {
 		return ErrNotStored
 	}
 	return cmd.Err()
 }
 
-func (c *redisClient) Delete(key string) error {
-	err := c.client.Del(context.Background(), key)
+func (c *redisClient) Delete(ctx context.Context, key string) error {
+	err := c.client.Del(ctx, key)
 	return err.Err()
 }
 
-func (c *redisClient) Increment(key string, delta uint64) (uint64, error) {
-	cmd := c.client.IncrBy(context.Background(), key, int64(delta))
+func (c *redisClient) Increment(ctx context.Context, key string, delta uint64) (uint64, error) {
+	cmd := c.client.IncrBy(ctx, key, int64(delta))
 	val, err := cmd.Result()
 	return uint64(val), err
 }
 
-func (c *redisClient) Decrement(key string, delta uint64) (uint64, error) {
-	cmd := c.client.DecrBy(context.Background(), key, int64(delta))
+func (c *redisClient) Decrement(ctx context.Context, key string, delta uint64) (uint64, error) {
+	cmd := c.client.DecrBy(ctx, key, int64(delta))
 	val, err := cmd.Result()
 	return uint64(val), err
 }


### PR DESCRIPTION
Having the context parameter will allow propagating context cancelations, timeouts, and leverage redis' opentelemetry capabilities. 

This is a breaking change and will introduce a v2