### PR TITLE
Remove deprecated TtlForExpiration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add context as first argument
 - Remove deprecated encoding, use github.com/Shopify/go-encoding directly instead.
+- Remove deprecated TtlForExpiration, use `time.Until` instead.
 
 ## v1
 

--- a/client.go
+++ b/client.go
@@ -38,13 +38,6 @@ type Client interface {
 
 var NeverExpire time.Time
 
-// TtlForExpiration returns the duration until t
-// Deprecated: Do not use the exported function
-// nolint:golint
-func TtlForExpiration(t time.Time) time.Duration {
-	return ttlForExpiration(t)
-}
-
 func ttlForExpiration(t time.Time) time.Duration {
 	if t.IsZero() {
 		return 0


### PR DESCRIPTION
Since we are starting a v2 with #49, also remove the deprecated method.