### PR TITLE
Bump requirement to go 1.15

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -57,9 +57,8 @@ jobs:
     strategy:
       matrix:
         go-version:
-        - 1.13.x
-        - 1.14.x
         - 1.15.x
+        - 1.16.x
 
     steps:
     - name: Checkout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add context as first argument
 - Remove deprecated encoding, use github.com/Shopify/go-encoding directly instead.
 - Remove deprecated TtlForExpiration, use `time.Until` instead.
+- Bump required Go version to 1.15
 
 ## v1
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Inspired from https://github.com/gookit/cache, but designed to be wrapped, simil
 
 # Requirements
 
-- [Go 1.13+](http://golang.org/dl/)
+- [Go 1.15+](http://golang.org/dl/)
 
 # Installation
 

--- a/dev.yml
+++ b/dev.yml
@@ -2,7 +2,7 @@ name: go-cache
 
 up:
   - go:
-      version: "1.15.2"
+      version: "1.15.12"
       modules: true
       tools:
         - github.com/alecthomas/gometalinter

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Shopify/go-cache
 
-go 1.13
+go 1.15
 
 require (
 	github.com/Shopify/go-encoding v0.0.0-20201030134245-d04c0dbe045f


### PR DESCRIPTION
In preparation to releasing v2, bump the minimum go version to 1.15.

1.14 is required for the new versions of redis anyway: https://github.com/Shopify/go-cache/pull/48