### PR TITLE
Add a cache lock implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Add a `prefixClient` wrapper
+- Add a `cachelock` package, to acquire and release locks on keys using a `cache.Client`
 
 ## [v2.0.1] - 2021-05-26
 ### Changed

--- a/cachelock/cache_locker.go
+++ b/cachelock/cache_locker.go
@@ -1,0 +1,106 @@
+package cachelock
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"math/rand"
+	"time"
+
+	"github.com/Shopify/go-cache/v2"
+)
+
+const tokenLength = 16
+
+type cacheLocker struct {
+	client        cache.Client
+	expiration    time.Duration
+	retryStrategy func() RetryAttempt
+}
+
+func New(client cache.Client, expiration time.Duration, retryStrategy RetryStrategy) Locker {
+	return &cacheLocker{
+		client:        client,
+		expiration:    expiration,
+		retryStrategy: retryStrategy,
+	}
+}
+
+func (l *cacheLocker) Acquire(ctx context.Context, key string) (Lock, error) {
+	retry := l.retryStrategy()
+	token, err := randomToken(tokenLength)
+	if err != nil {
+		return nil, fmt.Errorf("generating token: %w", err)
+	}
+
+	expiration := time.Now().Add(l.expiration)
+	ctx, cancel := context.WithDeadline(ctx, expiration)
+	defer cancel()
+
+	var timer *time.Timer
+	for {
+		err := l.client.Add(ctx, key, token, expiration)
+		if err == nil {
+			return &cacheLock{client: l.client, key: key, token: token}, nil
+		} else if !errors.Is(err, cache.ErrNotStored) {
+			return nil, fmt.Errorf("locking: %w", err)
+		}
+
+		backoff := retry.NextBackoff()
+		if backoff < 1 {
+			return nil, ErrNotAcquired
+		}
+
+		if timer == nil {
+			timer = time.NewTimer(backoff)
+			defer timer.Stop()
+		} else {
+			timer.Reset(backoff)
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil, ErrNotAcquired
+		case <-timer.C:
+		}
+	}
+}
+
+func randomToken(length int) (string, error) {
+	tok := make([]byte, length)
+
+	if _, err := rand.Read(tok); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(tok), nil
+
+}
+
+type cacheLock struct {
+	client cache.Client
+	key    string
+	token  string
+}
+
+func (r *cacheLock) Release(ctx context.Context) error {
+	var stored string
+	err := r.client.Get(ctx, r.key, &stored)
+	if err != nil {
+		if errors.Is(err, cache.ErrCacheMiss) {
+			err = ErrNotReleased
+		}
+		return err
+	}
+
+	if stored != r.token {
+		return ErrNotReleased
+	}
+
+	// This implementation checks for the lock being held and still having the same token,
+	// but it's _possible_ there's a race condition here and the lock will be tampered with before we delete it here.
+	// However, that should be extremely unlikely, since only one thread should be able to lock or attempt unlocking at the same time.
+	// Therefore, this particular implementation takes the shortcut of not dealing with that race condition.
+
+	return r.client.Delete(ctx, r.key)
+}

--- a/cachelock/cache_locker_test.go
+++ b/cachelock/cache_locker_test.go
@@ -1,0 +1,67 @@
+package cachelock
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/Shopify/go-cache/v2"
+)
+
+func Test_Lock_Release(t *testing.T) {
+	ctx := context.Background()
+	r := newTestCacheLock()
+
+	lock, err := r.Acquire(ctx, "foo")
+	require.NoError(t, err)
+
+	err = lock.Release(ctx)
+	require.NoError(t, err)
+
+	lock, err = r.Acquire(ctx, "foo")
+	require.NoError(t, err)
+
+	err = lock.Release(ctx)
+	require.NoError(t, err)
+}
+
+func Test_Lock_Different_Key(t *testing.T) {
+	ctx := context.Background()
+	r := newTestCacheLock()
+
+	_, err := r.Acquire(ctx, "foo")
+	require.NoError(t, err)
+
+	_, err = r.Acquire(ctx, "bar")
+	require.NoError(t, err)
+}
+
+func Test_Release(t *testing.T) {
+	ctx := context.Background()
+	r := newTestCacheLock()
+
+	lock, err := r.Acquire(ctx, "foo")
+	require.NoError(t, err)
+
+	err = lock.Release(ctx)
+	require.NoError(t, err)
+
+	err = lock.Release(ctx)
+	require.Equal(t, ErrNotReleased, err)
+}
+
+func Test_Lock_Concurrent_With_Retry(t *testing.T) {
+	ctx := context.Background()
+	r := newTestCacheLock()
+
+	_, err := r.Acquire(ctx, "foo")
+	require.NoError(t, err)
+
+	_, err = r.Acquire(ctx, "foo")
+	require.Equal(t, ErrNotAcquired, err)
+}
+
+func newTestCacheLock() Locker {
+	return New(cache.NewMemoryClient(), DefaultLockExpiration, NoRetryStrategy)
+}

--- a/cachelock/lock.go
+++ b/cachelock/lock.go
@@ -1,0 +1,24 @@
+package cachelock
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+var (
+	ErrNotAcquired = errors.New("lock not acquired")
+	ErrNotReleased = errors.New("lock not released")
+)
+
+const DefaultLockExpiration = time.Minute * 5
+
+// Locker is a service that provides a lock for a resource.
+type Locker interface {
+	Acquire(ctx context.Context, key string) (Lock, error)
+}
+
+// Lock is a handle on an acquired lock.
+type Lock interface {
+	Release(context.Context) error
+}

--- a/cachelock/mock_locker.go
+++ b/cachelock/mock_locker.go
@@ -1,0 +1,45 @@
+package cachelock
+
+import (
+	"context"
+
+	"github.com/stretchr/testify/mock"
+)
+
+var _ Locker = (*MockLocker)(nil)
+var _ Lock = (*MockLock)(nil)
+
+func ExpectAcquireAndRelease(locker *MockLocker, key string) *MockLock {
+	lock := NewMockLock()
+	locker.On("Acquire", mock.Anything, key).Return(lock, nil)
+	lock.On("Release", mock.Anything).Return(nil)
+	return lock
+}
+
+func NewMockLocker() *MockLocker {
+	return &MockLocker{}
+}
+
+type MockLocker struct {
+	mock.Mock
+}
+
+func (m *MockLocker) Acquire(ctx context.Context, key string) (Lock, error) {
+	args := m.Called(ctx, key)
+	if args.Error(1) != nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(Lock), args.Error(1)
+}
+
+func NewMockLock() *MockLock {
+	return &MockLock{}
+}
+
+type MockLock struct {
+	mock.Mock
+}
+
+func (m *MockLock) Release(ctx context.Context) error {
+	return m.Called(ctx).Error(0)
+}

--- a/cachelock/mock_locker_test.go
+++ b/cachelock/mock_locker_test.go
@@ -1,0 +1,25 @@
+package cachelock
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewMockForKey(t *testing.T) {
+	locker := NewMockLocker()
+	ctx := context.Background()
+
+	lock := ExpectAcquireAndRelease(locker, "foo")
+
+	acquired, err := locker.Acquire(ctx, "foo")
+	require.NoError(t, err)
+	require.Equal(t, lock, acquired)
+
+	err = acquired.Release(ctx)
+	require.NoError(t, err)
+
+	locker.AssertExpectations(t)
+	lock.AssertExpectations(t)
+}

--- a/cachelock/retry.go
+++ b/cachelock/retry.go
@@ -1,0 +1,76 @@
+package cachelock
+
+import (
+	"sync/atomic"
+	"time"
+)
+
+var (
+	NoRetryStrategy = LinearBackoffStrategy(0)
+)
+
+type RetryStrategy func() RetryAttempt
+
+// RetryAttempt allows to customise the lock retry strategy.
+type RetryAttempt interface {
+	// NextBackoff returns the next backoff duration.
+	NextBackoff() time.Duration
+}
+
+// NoRetry acquire the lock only once.
+func NoRetry() RetryAttempt {
+	return linearBackoff(0)
+}
+
+type linearBackoff time.Duration
+
+// LinearBackoff allows retries regularly with customized intervals
+func LinearBackoff(backoff time.Duration) RetryAttempt {
+	return linearBackoff(backoff)
+}
+
+func LinearBackoffStrategy(backoff time.Duration) RetryStrategy {
+	attempt := linearBackoff(backoff) // idempotent, so memoize it
+	return func() RetryAttempt {
+		return attempt
+	}
+}
+
+func (r linearBackoff) NextBackoff() time.Duration {
+	return time.Duration(r)
+}
+
+type exponentialBackoff struct {
+	cnt uint64
+
+	min, max time.Duration
+}
+
+// ExponentialBackoff strategy is an optimization strategy with a retry time of 2**n milliseconds (n means number of times).
+// You can set a minimum and maximum value, the recommended minimum value is not less than 16ms.
+func ExponentialBackoff(min, max time.Duration) RetryAttempt {
+	return &exponentialBackoff{min: min, max: max}
+}
+
+func ExponentialBackoffStrategy(min, max time.Duration) RetryStrategy {
+	return func() RetryAttempt {
+		return ExponentialBackoff(min, max)
+	}
+}
+
+func (r *exponentialBackoff) NextBackoff() time.Duration {
+	cnt := atomic.AddUint64(&r.cnt, 1)
+
+	ms := 2 << 25
+	if cnt < 25 {
+		ms = 2 << cnt
+	}
+
+	if d := time.Duration(ms) * time.Millisecond; d < r.min {
+		return r.min
+	} else if r.max != 0 && d > r.max {
+		return r.max
+	} else {
+		return d
+	}
+}

--- a/cachelock/retry_test.go
+++ b/cachelock/retry_test.go
@@ -1,0 +1,35 @@
+package cachelock
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRetryStrategy(t *testing.T) {
+	t.Run("no-retry", func(t *testing.T) {
+		retry := NoRetry()
+		require.Equal(t, time.Duration(0), retry.NextBackoff())
+	})
+
+	t.Run("linear backoff", func(t *testing.T) {
+		retry := LinearBackoff(time.Second)
+		require.Equal(t, time.Second, retry.NextBackoff())
+		require.Equal(t, time.Second, retry.NextBackoff())
+	})
+
+	t.Run("exponential", func(t *testing.T) {
+		retry := ExponentialBackoff(10*time.Millisecond, 300*time.Millisecond)
+		require.Equal(t, 10*time.Millisecond, retry.NextBackoff())
+		require.Equal(t, 10*time.Millisecond, retry.NextBackoff())
+		require.Equal(t, 16*time.Millisecond, retry.NextBackoff())
+		require.Equal(t, 32*time.Millisecond, retry.NextBackoff())
+		require.Equal(t, 64*time.Millisecond, retry.NextBackoff())
+		require.Equal(t, 128*time.Millisecond, retry.NextBackoff())
+		require.Equal(t, 256*time.Millisecond, retry.NextBackoff())
+		require.Equal(t, 300*time.Millisecond, retry.NextBackoff())
+		require.Equal(t, 300*time.Millisecond, retry.NextBackoff())
+		require.Equal(t, 300*time.Millisecond, retry.NextBackoff())
+	})
+}

--- a/go.sum
+++ b/go.sum
@@ -49,6 +49,7 @@ github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=


### PR DESCRIPTION
Inspired from https://github.com/bsm/redislock, but using a generic `cache.Client` instead of Redis proprietary APIs.

⚠️ This implementation checks for the lock being held and still having the same token, but it's possible there's a race condition where the lock would be tampered with before we delete it.
However, that should be extremely unlikely, since only one thread should be able to lock or attempt unlocking at the same time.
Therefore, this particular implementation takes the shortcut of not dealing with that race condition.

It would be possible for the lock to expire between the retrieval and the release, so this adds a buffer to avoid doing so if too close to the expiration. See comments for explanation.