### PR TITLE
Add attempt bound retry strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add an attempt bound retry strategy
 ### Changed
 - Fix docs for the client `Get` method
 

--- a/cachelock/retry.go
+++ b/cachelock/retry.go
@@ -80,13 +80,13 @@ func AttemptBoundRetryStrategy(maxAttempts int, retryStrategy RetryStrategy) Ret
 		panic("max attempts must be greater than 0")
 	}
 	return func() RetryAttempt {
-		return &attemptBoundRetryAttempt{maxAttempts: maxAttempts, retryAttempt: retryStrategy()}
+		return &attemptBoundRetryAttempt{maxAttempts: uint64(maxAttempts), retryAttempt: retryStrategy()}
 	}
 }
 
 type attemptBoundRetryAttempt struct {
-	attempts     int
-	maxAttempts  int
+	attempts     uint64
+	maxAttempts  uint64
 	retryAttempt RetryAttempt
 }
 
@@ -94,6 +94,6 @@ func (r *attemptBoundRetryAttempt) NextBackoff() time.Duration {
 	if r.attempts >= r.maxAttempts {
 		return NoRetry().NextBackoff()
 	}
-	r.attempts++
+	atomic.AddUint64(&r.attempts, 1)
 	return r.retryAttempt.NextBackoff()
 }

--- a/cachelock/retry_test.go
+++ b/cachelock/retry_test.go
@@ -32,4 +32,15 @@ func TestRetryStrategy(t *testing.T) {
 		require.Equal(t, 300*time.Millisecond, retry.NextBackoff())
 		require.Equal(t, 300*time.Millisecond, retry.NextBackoff())
 	})
+	t.Run("attempt bound", func(t *testing.T) {
+		count := 5
+		backoff := 100 * time.Millisecond
+		attempt := AttemptBoundRetryStrategy(count, func() RetryAttempt {
+			return LinearBackoff(backoff)
+		})()
+		for i := 0; i < 5; i++ {
+			require.Equal(t, backoff, attempt.NextBackoff())
+		}
+		require.Equal(t, NoRetry().NextBackoff(), attempt.NextBackoff())
+	})
 }


### PR DESCRIPTION
All other cache lockers will either retry never or indefinitely. This PR introduces attempt bound retry strategy.

Was working on this for https://github.com/Shopify/courier/pull/3958. Whether or not we use the strategy in the end I thought it would be helpful to have implemented in the library.

I didn't take the approach of atomically updating the counter because I thought that this strategy is not something that would be used in some kind of concurrent context.